### PR TITLE
Post non-form data

### DIFF
--- a/EtherCard.cpp
+++ b/EtherCard.cpp
@@ -369,6 +369,7 @@ void BufferFiller::emit_p(PGM_P fmt, ...) {
         }
         ptr += strlen((char*) ptr);
     }
+    *ptr = '\0'; // ensure string is terminated
     va_end(ap);
 }
 

--- a/EtherCard.h
+++ b/EtherCard.h
@@ -357,11 +357,15 @@ public:
     *     @param  additionalheaderline Pointer to c-string with additional HTTP header info
     *     @param  postval Pointer to c-string HTML Post value
     *     @param  callback Pointer to callback function to handle response
+    *     @param  content_type PROGMEM string specifying request content mime type or NULL for default
+    *     @param  accept_type PROGMEM string specifying response accepted mime type(s) or NULL for default
     *     @note   Request sent in main packetloop
     */
     static void httpPost (const char *urlbuf, const char *hoststr,
                           const char *additionalheaderline, const char *postval,
-                          void (*callback)(uint8_t,uint16_t,uint16_t));
+                          void (*callback)(uint8_t,uint16_t,uint16_t),
+                          const char *content_type = NULL,
+                          const char *accept_type = NULL);
 
     /**   @brief  Send NTP request
     *     @param  ntpip IP address of NTP server

--- a/tcpip.cpp
+++ b/tcpip.cpp
@@ -41,6 +41,8 @@ static const char *client_postval;
 static const char *client_urlbuf; // Pointer to c-string path part of HTTP request URL
 static const char *client_urlbuf_var; // Pointer to c-string filename part of HTTP request URL
 static const char *client_hoststr; // Pointer to c-string hostname of current HTTP request
+static const char *client_content_type; // Program memory string specifying httpPost request content type
+static const char *client_accept_type; // Program memory string specifying httpPost response type(s)
 static void (*icmp_cb)(uint8_t *ip); // Pointer to callback function for ICMP ECHO response handler (triggers when localhost recieves ping respnse (pong))
 static uint8_t destmacaddr[6]; // storing both dns server and destination mac addresses, but at different times because both are never needed at same time.
 static boolean waiting_for_dns_mac = false; //might be better to use bit flags and bitmask operations for these conditions
@@ -540,15 +542,17 @@ static uint16_t www_client_internal_datafill_cb(uint8_t fd) {
             bfill.emit_p(PSTR("POST $F HTTP/1.0\r\n"
                               "Host: $F\r\n"
                               "$F$S"
-                              "Accept: */*\r\n"
+                              "Accept: $F\r\n"
                               "Content-Length: $D\r\n"
-                              "Content-Type: application/x-www-form-urlencoded\r\n"
+                              "Content-Type: $F\r\n"
                               "\r\n"
                               "$S"), client_urlbuf,
                          client_hoststr,
                          ahl != 0 ? ahl : PSTR(""),
                          ahl != 0 ? "\r\n" : "",
+                         client_accept_type ? client_accept_type : PSTR("*/*"),
                          strlen(client_postval),
+                         client_content_type ? client_content_type : PSTR("application/x-www-form-urlencoded"),
                          client_postval);
         }
     }
@@ -579,12 +583,15 @@ void EtherCard::browseUrl (const char *urlbuf, const char *urlbuf_varpart, const
     www_fd = clientTcpReq(&www_client_internal_result_cb,&www_client_internal_datafill_cb,hisport);
 }
 
-void EtherCard::httpPost (const char *urlbuf, const char *hoststr, const char *additionalheaderline, const char *postval, void (*callback)(uint8_t,uint16_t,uint16_t)) {
+void EtherCard::httpPost (const char *urlbuf, const char *hoststr, const char *additionalheaderline, const char *postval, void (*callback)(uint8_t,uint16_t,uint16_t),
+        const char *content_type, const char *accept_type) {
     client_urlbuf = urlbuf;
     client_hoststr = hoststr;
     client_additionalheaderline = additionalheaderline;
     client_postval = postval;
     client_browser_cb = callback;
+    client_content_type = content_type;
+    client_accept_type = accept_type;
     www_fd = clientTcpReq(&www_client_internal_result_cb,&www_client_internal_datafill_cb,hisport);
 }
 


### PR DESCRIPTION
Parameterise Accept & Content-Type HTTP header values to allow posting
data other than application/x-www-form-urlencoded (e.g. JSON). Also
terminate BufferFiller::emit_p output so is usable as standard c string.
