### PR TITLE
Configure LED B to reflect tx/rx activity

### DIFF
--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -390,6 +390,9 @@ byte ENC28J60::initialize (uint16_t size, const byte* macaddr, byte csPin) {
     writeReg(ETXST, TXSTART_INIT);
     writeReg(ETXND, TXSTOP_INIT);
 
+    // Stretch pulses for LED, LED_A=Link, LED_B=activity
+    writePhy(PHLCON, 0x476);
+
     writeRegByte(ERXFCON, ERXFCON_UCEN|ERXFCON_CRCEN|ERXFCON_PMEN|ERXFCON_BCEN);
     writeReg(EPMM0, 0x303f);
     writeReg(EPMCS, 0xf7f9);


### PR DESCRIPTION
Initialize the PHLCON register to stretch pulses, make LED A link status and LED B RX/TX activity.  Before this change LED B only registered RX activity.