### PR TITLE
changed include of EtherCard.h to "local include"

### DIFF
--- a/EtherCard.cpp
+++ b/EtherCard.cpp
@@ -9,7 +9,7 @@
 //
 // 2010-05-19 <jc@wippler.nl>
 
-#include <EtherCard.h>
+#include "EtherCard.h"
 #include <stdarg.h>
 #include <avr/eeprom.h>
 
@@ -77,7 +77,7 @@ uint8_t Stash::freeCount () {
     return count;
 }
 
-// create a new stash; make it the active stash; return the first block as a handle 
+// create a new stash; make it the active stash; return the first block as a handle
 uint8_t Stash::create () {
     uint8_t blk = allocBlock();
     load(WRITEBUF, blk);
@@ -85,7 +85,7 @@ uint8_t Stash::create () {
     bufs[WRITEBUF].head.first = bufs[0].head.last = blk;
     bufs[WRITEBUF].tail = sizeof (StashHeader);
     bufs[WRITEBUF].next = 0;
-    return open(blk); // you are now the active stash 
+    return open(blk); // you are now the active stash
 }
 
 // the stashheader part only contains reasonable data if we are the first block
@@ -140,7 +140,7 @@ char Stash::get () {
     return b;
 }
 
-// fetchbyte(last, 62) is tail, i.e., number of characters in last block 
+// fetchbyte(last, 62) is tail, i.e., number of characters in last block
 uint16_t Stash::size () {
     return 63 * count + fetchByte(last, 62) - sizeof (StashHeader);
 }
@@ -153,8 +153,8 @@ static char* wtoa (uint16_t value, char* ptr) {
     return ptr;
 }
 
-// write information about the fmt string and the arguments into special page/block 0    
-// block 0 is initially marked as allocated and never returned by allocateBlock 
+// write information about the fmt string and the arguments into special page/block 0
+// block 0 is initially marked as allocated and never returned by allocateBlock
 void Stash::prepare (const char* fmt PROGMEM, ...) {
     Stash::load(WRITEBUF, 0);
     uint16_t* segs = Stash::bufs[WRITEBUF].words;


### PR DESCRIPTION
Hi,

i encountered problems while including the library in my own Arduino project because of the include syntax. The file EtherCard.h coudn't be found. This change fixed my problem.

Thanks,
Kristian