### PR TITLE
refs #306 - fix examples - add CS/SS pin in begin method

### DIFF
--- a/examples/backSoon/backSoon.ino
+++ b/examples/backSoon/backSoon.ino
@@ -1,6 +1,6 @@
 // Present a "Will be back soon web page", as stand-in webserver.
 // 2011-01-30 <jc@wippler.nl> http://opensource.org/licenses/mit-license.php
- 
+
 #include <EtherCard.h>
 
 #define STATIC 0  // set to 1 to disable DHCP (adjust myip/gwip values below)
@@ -39,8 +39,8 @@ const char page[] PROGMEM =
 void setup(){
   Serial.begin(57600);
   Serial.println("\n[backSoon]");
-  
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println( "Failed to access Ethernet controller");
 #if STATIC
   ether.staticSetup(myip, gwip);
@@ -50,8 +50,8 @@ void setup(){
 #endif
 
   ether.printIp("IP:  ", ether.myip);
-  ether.printIp("GW:  ", ether.gwip);  
-  ether.printIp("DNS: ", ether.dnsip);  
+  ether.printIp("GW:  ", ether.gwip);
+  ether.printIp("DNS: ", ether.dnsip);
 }
 
 void loop(){

--- a/examples/etherNode/etherNode.ino
+++ b/examples/etherNode/etherNode.ino
@@ -6,7 +6,7 @@
 //
 // This sketch is derived from RF12eth.pde:
 // May 2010, Andras Tucsni, http://opensource.org/licenses/mit-license.php
- 
+
 #include <EtherCard.h>
 #include <JeeLib.h>
 #include <avr/eeprom.h>
@@ -67,9 +67,9 @@ static void saveConfig() {
 
 #if DEBUG
 static int freeRam () {
-  extern int __heap_start, *__brkval; 
-  int v; 
-  return (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval); 
+  extern int __heap_start, *__brkval;
+  int v;
+  return (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval);
 }
 #endif
 
@@ -79,8 +79,8 @@ void setup(){
     Serial.println("\n[etherNode]");
 #endif
     loadConfig();
-    
-    if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+
+    if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) // CS/SS hookup pin 8/10 for normal shield; 53 for mega
       Serial.println( "Failed to access Ethernet controller");
     if (!ether.dhcpSetup())
       Serial.println("DHCP failed");
@@ -89,7 +89,7 @@ void setup(){
 #endif
 }
 
-const char okHeader[] PROGMEM = 
+const char okHeader[] PROGMEM =
     "HTTP/1.0 200 OK\r\n"
     "Content-Type: text/html\r\n"
     "Pragma: no-cache\r\n"
@@ -99,7 +99,7 @@ static void homePage(BufferFiller& buf) {
     word mhz = config.band == 4 ? 433 : config.band == 8 ? 868 : 915;
     buf.emit_p(PSTR("$F\r\n"
         "<meta http-equiv='refresh' content='$D'/>"
-        "<title>RF12 etherNode - $D MHz, group $D</title>" 
+        "<title>RF12 etherNode - $D MHz, group $D</title>"
         "RF12 etherNode - $D MHz, group $D "
             "- <a href='c'>configure</a> - <a href='s'>send packet</a>"
         "<h3>Last $D messages:</h3>"
@@ -245,7 +245,7 @@ void loop(){
                 "HTTP/1.0 401 Unauthorized\r\n"
                 "Content-Type: text/html\r\n"
                 "\r\n"
-                "<h1>401 Unauthorized</h1>"));  
+                "<h1>401 Unauthorized</h1>"));
         ether.httpServerReply(bfill.position()); // send web page data
     }
 
@@ -253,7 +253,7 @@ void loop(){
     if (rf12_recvDone() && rf12_crc == 0 && (rf12_hdr & RF12_HDR_CTL) == 0) {
         history_rcvd[next_msg][0] = rf12_hdr;
         for (byte i = 0; i < rf12_len; ++i)
-            if (i < MESSAGE_TRUNC) 
+            if (i < MESSAGE_TRUNC)
                 history_rcvd[next_msg][i+1] = rf12_data[i];
         history_len[next_msg] = rf12_len < MESSAGE_TRUNC ? rf12_len+1
                                                          : MESSAGE_TRUNC+1;
@@ -267,7 +267,7 @@ void loop(){
             rf12_sendStart(RF12_ACK_REPLY);
         }
     }
-    
+
     // send a data packet out if requested
     if (outCount >= 0 && rf12_canSend()) {
         rf12_sendStart(outDest, outBuf, outCount);

--- a/examples/getDHCPandDNS/getDHCPandDNS.ino
+++ b/examples/getDHCPandDNS/getDHCPandDNS.ino
@@ -24,13 +24,13 @@ static void my_result_cb (byte status, word off, word len) {
 void setup () {
   Serial.begin(57600);
   Serial.println("\n[getDHCPandDNS]");
-  
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println( "Failed to access Ethernet controller");
 
   if (!ether.dhcpSetup())
     Serial.println("DHCP failed");
-  
+
   ether.printIp("My IP: ", ether.myip);
   // ether.printIp("Netmask: ", ether.mymask);
   ether.printIp("GW IP: ", ether.gwip);
@@ -39,14 +39,14 @@ void setup () {
   if (!ether.dnsLookup(website))
     Serial.println("DNS failed");
   ether.printIp("Server: ", ether.hisip);
-  
+
   timer = - REQUEST_RATE; // start timing out right away
 }
 
 void loop () {
-    
+
   ether.packetLoop(ether.packetReceive());
-  
+
   if (millis() > timer + REQUEST_RATE) {
     timer = millis();
     Serial.println("\n>>> REQ");

--- a/examples/getStaticIP/getStaticIP.ino
+++ b/examples/getStaticIP/getStaticIP.ino
@@ -30,8 +30,8 @@ static void my_result_cb (byte status, word off, word len) {
 void setup () {
   Serial.begin(57600);
   Serial.println("\n[getStaticIP]");
-  
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println( "Failed to access Ethernet controller");
 
   ether.staticSetup(myip, gwip);
@@ -42,13 +42,13 @@ void setup () {
   while (ether.clientWaitingGw())
     ether.packetLoop(ether.packetReceive());
   Serial.println("Gateway found");
-  
+
   timer = - REQUEST_RATE; // start timing out right away
 }
 
 void loop () {
   ether.packetLoop(ether.packetReceive());
-  
+
   if (millis() > timer + REQUEST_RATE) {
     timer = millis();
     Serial.println("\n>>> REQ");

--- a/examples/getViaDNS/getViaDNS.ino
+++ b/examples/getViaDNS/getViaDNS.ino
@@ -28,8 +28,8 @@ static void my_result_cb (byte status, word off, word len) {
 void setup () {
   Serial.begin(57600);
   Serial.println("\n[getViaDNS]");
-  
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println( "Failed to access Ethernet controller");
 
   ether.staticSetup(myip, gwip);
@@ -37,13 +37,13 @@ void setup () {
   if (!ether.dnsLookup(website))
     Serial.println("DNS failed");
   ether.printIp("Server: ", ether.hisip);
-  
+
   timer = - REQUEST_RATE; // start timing out right away
 }
 
 void loop () {
   ether.packetLoop(ether.packetReceive());
-  
+
   if (millis() > timer + REQUEST_RATE) {
     timer = millis();
     Serial.println("\n>>> REQ");

--- a/examples/nanether/nanether.ino
+++ b/examples/nanether/nanether.ino
@@ -20,7 +20,7 @@ void setup(void)
 
     /* Check that the Ethernet controller exists */
     Serial.println("Initialising the Ethernet controller");
-    if (ether.begin(sizeof Ethernet::buffer, mac, 8) == 0) {
+    if (ether.begin(sizeof Ethernet::buffer, mac, 8) == 0){ // CS/SS hookup pin 8/10 for normal shield; 53 for mega
         Serial.println( "Ethernet controller NOT initialised");
         while (true)
             /* MT */ ;

--- a/examples/notifyMyAndroid/notifyMyAndroid.ino
+++ b/examples/notifyMyAndroid/notifyMyAndroid.ino
@@ -56,7 +56,7 @@ void setup () {
   Serial.begin(57600);
   Serial.println("\nStarting Notify My Android Example");
 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0) // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));

--- a/examples/ntpClient/ntpClient.ino
+++ b/examples/ntpClient/ntpClient.ino
@@ -29,7 +29,7 @@ void setup() {
   Serial.begin(9600);
   Serial.println(F("\n[EtherCard NTP Client]"));
 
-  if (ether.begin(sizeof Ethernet::buffer, myMac) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, myMac, 8) == 0) // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));

--- a/examples/persistence/persistence.ino
+++ b/examples/persistence/persistence.ino
@@ -16,7 +16,7 @@ const char website[] PROGMEM = "textfiles.com";
 uint32_t nextSeq;
 // called when the client request is complete
 static void my_callback (byte status, word off, word len) {
-   
+
     if (strncmp_P((char*) Ethernet::buffer+off,PSTR("HTTP"),4) == 0) {
         Serial.println(">>>");
         // first reply packet
@@ -24,19 +24,19 @@ static void my_callback (byte status, word off, word len) {
     }
 
     if (nextSeq != ether.getSequenceNumber()) { Serial.print(F("<IGNORE DUPLICATE(?) PACKET>")); return; }
-    
+
     uint16_t payloadlength = ether.getTcpPayloadLength();
     int16_t chunk_size   = BUFFERSIZE-off-1;
     int16_t char_written = 0;
     int16_t char_in_buf  = chunk_size < payloadlength ? chunk_size : payloadlength;
-      
+
     while (char_written < payloadlength) {
         Serial.write((char*) Ethernet::buffer+off,char_in_buf);
         char_written += char_in_buf;
-        
+
         char_in_buf = ether.readPacketSlice((char*) Ethernet::buffer+off,chunk_size,off+char_written);
     }
-    
+
     nextSeq += ether.getTcpPayloadLength();
 }
 
@@ -44,26 +44,26 @@ void setup () {
     Serial.begin(57600);
     Serial.println(F("\n[Persistence+readPacketSlice]"));
 
-  
-    if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+
+    if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0){ // CS/SS hookup pin 8/10 for normal shield; 53 for mega
         Serial.println(F("Failed to access Ethernet controller"));
     if (!ether.dhcpSetup())
         Serial.println(F("DHCP failed"));
 
     ether.printIp("IP:  ", ether.myip);
-    ether.printIp("GW:  ", ether.gwip);  
-    ether.printIp("DNS: ", ether.dnsip);  
+    ether.printIp("GW:  ", ether.gwip);
+    ether.printIp("DNS: ", ether.dnsip);
 
     if (!ether.dnsLookup(website))
         Serial.println("DNS failed");
-    
+
     ether.printIp("SRV: ", ether.hisip);
     ether.persistTcpConnection(true);
 }
 
 void loop () {
   ether.packetLoop(ether.packetReceive());
-  
+
   static uint32_t timer =  0;
   if (millis() > timer) {
       timer = millis() + 7000;

--- a/examples/pings/pings.ino
+++ b/examples/pings/pings.ino
@@ -17,8 +17,8 @@ static void gotPinged (byte* ptr) {
 void setup () {
   Serial.begin(57600);
   Serial.println("\n[pings]");
-  
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0)
+
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0){ // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));
@@ -34,10 +34,10 @@ void setup () {
   ether.parseIp(ether.hisip, "74.125.77.99");
 #endif
   ether.printIp("SRV: ", ether.hisip);
-    
+
   // call this to report others pinging us
   ether.registerPingCallback(gotPinged);
-  
+
   timer = -9999999; // start timing out right away
   Serial.println();
 }
@@ -45,14 +45,14 @@ void setup () {
 void loop () {
   word len = ether.packetReceive(); // go receive new packets
   word pos = ether.packetLoop(len); // respond to incoming pings
-  
+
   // report whenever a reply to our outgoing ping comes back
   if (len > 0 && ether.packetLoopIcmpCheckReply(ether.hisip)) {
     Serial.print("  ");
     Serial.print((micros() - timer) * 0.001, 3);
     Serial.println(" ms");
   }
-  
+
   // ping a remote server once every few seconds
   if (micros() - timer >= 5000000) {
     ether.printIp("Pinging: ", ether.hisip);

--- a/examples/rbbb_server/rbbb_server.ino
+++ b/examples/rbbb_server/rbbb_server.ino
@@ -11,7 +11,7 @@ byte Ethernet::buffer[500];
 BufferFiller bfill;
 
 void setup () {
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0){ // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println(F("Failed to access Ethernet controller"));
   ether.staticSetup(myip);
 }
@@ -28,7 +28,7 @@ static word homePage() {
     "Pragma: no-cache\r\n"
     "\r\n"
     "<meta http-equiv='refresh' content='1'/>"
-    "<title>RBBB server</title>" 
+    "<title>RBBB server</title>"
     "<h1>$D$D:$D$D:$D$D</h1>"),
       h/10, h%10, m/10, m%10, s/10, s%10);
   return bfill.position();
@@ -37,7 +37,7 @@ static word homePage() {
 void loop () {
   word len = ether.packetReceive();
   word pos = ether.packetLoop(len);
-  
+
   if (pos)  // check if valid tcp data is received
     ether.httpServerReply(homePage()); // send web page data
 }

--- a/examples/stashTest/stashTest.ino
+++ b/examples/stashTest/stashTest.ino
@@ -46,9 +46,9 @@ void dumpStash (const char* msg, void* ptr) {
 void setup () {
   Serial.begin(57600);
   Serial.println("\n[stashTest]");
-  ether.begin(sizeof Ethernet::buffer, mymac);
-  
-#if 1  
+  ether.begin(sizeof Ethernet::buffer, mymac, 8); // CS/SS hookup pin 8/10 for normal shield; 53 for mega
+
+#if 1
   Stash buf;
   dumpStash("> AAA", &buf);
   byte fd = buf.create();
@@ -85,7 +85,7 @@ void setup () {
   Serial.println();
   dumpStash("> GGG", &buf);
 #endif
-  
+
   Stash buf2;
   byte fd2 = buf2.create();
   buf2.print("<XYZ>");
@@ -93,7 +93,7 @@ void setup () {
   buf2.load(1, fd2);
   dumpBlock("SECOND", 1);
   dumpStash("> HHH", &buf2);
-  
+
   Stash::prepare(PSTR("a $S b $F c $D d $H e"),
                   "123", PSTR("4567"), -12345, fd2);
   dumpBlock("BUFFER", 0);

--- a/examples/testDHCP/testDHCP.ino
+++ b/examples/testDHCP/testDHCP.ino
@@ -23,14 +23,14 @@ void setup () {
       Serial.print(':');
   }
   Serial.println();
-  
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0){ // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println(F("Failed to access Ethernet controller"));
 
   Serial.println(F("Setting up DHCP"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));
-  
+
   ether.printIp("My IP: ", ether.myip);
   ether.printIp("Netmask: ", ether.netmask);
   ether.printIp("GW IP: ", ether.gwip);

--- a/examples/twitter/twitter.ino
+++ b/examples/twitter/twitter.ino
@@ -1,7 +1,7 @@
-// Twitter client sketch for ENC28J60 based Ethernet Shield. Uses 
+// Twitter client sketch for ENC28J60 based Ethernet Shield. Uses
 // arduino-tweet.appspot.com as a OAuth gateway.
 // Step by step instructions:
-// 
+//
 //  1. Get a oauth token:
 //     http://arduino-tweet.appspot.com/oauth/twitter/login
 //  2. Put the token value in the TOKEN define below
@@ -57,14 +57,14 @@ void setup () {
   Serial.begin(57600);
   Serial.println("\n[Twitter Client]");
 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0){ // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));
 
   ether.printIp("IP:  ", ether.myip);
-  ether.printIp("GW:  ", ether.gwip);  
-  ether.printIp("DNS: ", ether.dnsip);  
+  ether.printIp("GW:  ", ether.gwip);
+  ether.printIp("DNS: ", ether.dnsip);
 
   if (!ether.dnsLookup(website))
     Serial.println(F("DNS failed"));

--- a/examples/udpClientSendOnly/udpClientSendOnly.ino
+++ b/examples/udpClientSendOnly/udpClientSendOnly.ino
@@ -12,27 +12,27 @@ const int srcPort PROGMEM = 4321;
 void setup () {
   Serial.begin(9600);
 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0){ // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println( "Failed to access Ethernet controller");
   if (!ether.dhcpSetup())
     Serial.println("DHCP failed");
 
   ether.printIp("IP:  ", ether.myip);
-  ether.printIp("GW:  ", ether.gwip);  
-  ether.printIp("DNS: ", ether.dnsip);  
+  ether.printIp("GW:  ", ether.gwip);
+  ether.printIp("DNS: ", ether.dnsip);
 
   if (!ether.dnsLookup(website))
     Serial.println("DNS failed");
-    
+
   ether.printIp("SRV: ", ether.hisip);
 }
 
 char textToSend[] = "test 123";
 
-void loop () {  
+void loop () {
     if (millis() > timer) {
-      timer = millis() + 5000;  
-     //static void sendUdp (char *data,uint8_t len,uint16_t sport, uint8_t *dip, uint16_t dport);      
-     ether.sendUdp(textToSend, sizeof(textToSend), srcPort, ether.hisip, dstPort );   
+      timer = millis() + 5000;
+     //static void sendUdp (char *data,uint8_t len,uint16_t sport, uint8_t *dip, uint16_t dport);
+     ether.sendUdp(textToSend, sizeof(textToSend), srcPort, ether.hisip, dstPort );
   }
 }

--- a/examples/udpListener/udpListener.ino
+++ b/examples/udpListener/udpListener.ino
@@ -23,13 +23,13 @@ byte Ethernet::buffer[500]; // tcp/ip send and receive buffer
 //callback that prints received packets to the serial port
 void udpSerialPrint(uint16_t dest_port, uint8_t src_ip[IP_LEN], uint16_t src_port, const char *data, uint16_t len){
   IPAddress src(src_ip[0],src_ip[1],src_ip[2],src_ip[3]);
-  
+
   Serial.print("dest_port: ");
   Serial.println(dest_port);
   Serial.print("src_port: ");
   Serial.println(src_port);
-  
-  
+
+
   Serial.print("src_port: ");
   ether.printIp(src_ip);
   Serial.println("data: ");
@@ -40,7 +40,7 @@ void setup(){
   Serial.begin(57600);
   Serial.println(F("\n[backSoon]"));
 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0)
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0){ // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println(F("Failed to access Ethernet controller"));
 #if STATIC
   ether.staticSetup(myip, gwip);

--- a/examples/webClient/webClient.ino
+++ b/examples/webClient/webClient.ino
@@ -23,14 +23,14 @@ void setup () {
   Serial.begin(57600);
   Serial.println(F("\n[webClient]"));
 
-  if (ether.begin(sizeof Ethernet::buffer, mymac) == 0) 
+  if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0){ // CS/SS hookup pin 8/10 for normal shield; 53 for mega
     Serial.println(F("Failed to access Ethernet controller"));
   if (!ether.dhcpSetup())
     Serial.println(F("DHCP failed"));
 
   ether.printIp("IP:  ", ether.myip);
-  ether.printIp("GW:  ", ether.gwip);  
-  ether.printIp("DNS: ", ether.dnsip);  
+  ether.printIp("GW:  ", ether.gwip);
+  ether.printIp("DNS: ", ether.dnsip);
 
 #if 1
   // use DNS to resolve the website's IP address
@@ -46,13 +46,13 @@ void setup () {
   byte hisip[] = { 192,168,1,1 };
   ether.copyIp(ether.hisip, hisip);
 #endif
-    
+
   ether.printIp("SRV: ", ether.hisip);
 }
 
 void loop () {
   ether.packetLoop(ether.packetReceive());
-  
+
   if (millis() > timer) {
     timer = millis() + 5000;
     Serial.println();

--- a/examples/xively/xively.ino
+++ b/examples/xively/xively.ino
@@ -34,21 +34,21 @@ void setup () {
 }
 
 
-void loop () { 
-  
+void loop () {
+
   //if correct answer is not received then re-initialize ethernet module
   if (res > 220){
-    initialize_ethernet(); 
+    initialize_ethernet();
   }
-  
+
   res = res + 1;
-  
+
   ether.packetLoop(ether.packetReceive());
-  
+
   //200 res = 10 seconds (50ms each res)
   if (res == 200) {
 
-    
+
     //Generate random info
     float demo = random(0,500);
     word one = random(0,500);
@@ -89,11 +89,11 @@ void loop () {
     website, PSTR(FEED), website, PSTR(APIKEY), stash.size(), sd);
 
     // send the packet - this also releases all stash buffers once done
-    session = ether.tcpSend(); 
+    session = ether.tcpSend();
   }
-  
+
    const char* reply = ether.tcpReply(session);
-   
+
    if (reply != 0) {
      res = 0;
      Serial.println(reply);
@@ -103,8 +103,8 @@ void loop () {
 
 
 
-void initialize_ethernet(void){  
-  for(;;){ // keep trying until you succeed 
+void initialize_ethernet(void){
+  for(;;){ // keep trying until you succeed
     //Reinitialize ethernet module
     pinMode(5, OUTPUT);
     Serial.println("Reseting Ethernet...");
@@ -113,19 +113,19 @@ void initialize_ethernet(void){
     digitalWrite(5, HIGH);
     delay(500);
 
-    if (ether.begin(sizeof Ethernet::buffer, mymac) == 0){ 
+    if (ether.begin(sizeof Ethernet::buffer, mymac, 8) == 0){ // CS/SS hookup pin 8/10 for normal shield; 53 for mega
       Serial.println( "Failed to access Ethernet controller");
       continue;
     }
-    
+
     if (!ether.dhcpSetup()){
       Serial.println("DHCP failed");
       continue;
     }
 
     ether.printIp("IP:  ", ether.myip);
-    ether.printIp("GW:  ", ether.gwip);  
-    ether.printIp("DNS: ", ether.dnsip);  
+    ether.printIp("GW:  ", ether.gwip);
+    ether.printIp("DNS: ", ether.dnsip);
 
     if (!ether.dnsLookup(website))
       Serial.println("DNS failed");


### PR DESCRIPTION
I've fixed the examples so they can work with the CS/SS pin argument of the begin method.
It was getting stalled without it.