### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=1.0.0
 author=Jean-Claude Wippler
 maintainer=Nicholas Humfrey
 sentence=EtherCard is an IPv4 driver for the ENC28J60 chip.
+paragraph=
 category=Communication
 url=https://github.com/njh/EtherCard
 architectures=avr


### PR DESCRIPTION
Missing paragraph field causes the Arduino IDE to display a warning whenever Library or Boards Manager is opened or a board from a different hardware package is selected:

Invalid library found in E:\arduino\libraries\EtherCard: Missing 'paragraph' from library

I didn't find any good text in the readme to fill the field with so I left it blank. If you want to suggest some text I'd be happy to update this PR.