### PR TITLE
Removed references to MACON2

### DIFF
--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -72,7 +72,6 @@ bool ENC28J60::promiscuous_enabled = false;
 #define EPKTCNT          (0x19|0x20)
 // Bank 2 registers
 #define MACON1           (0x00|0x40|0x80)
-#define MACON2           (0x01|0x40|0x80)
 #define MACON3           (0x02|0x40|0x80)
 #define MACON4           (0x03|0x40|0x80)
 #define MABBIPG          (0x04|0x40|0x80)
@@ -154,13 +153,6 @@ bool ENC28J60::promiscuous_enabled = false;
 #define MACON1_RXPAUS    0x04
 #define MACON1_PASSALL   0x02
 #define MACON1_MARXEN    0x01
-// ENC28J60 MACON2 Register Bit Definitions
-#define MACON2_MARST     0x80
-#define MACON2_RNDRST    0x40
-#define MACON2_MARXRST   0x08
-#define MACON2_RFUNRST   0x04
-#define MACON2_MATXRST   0x02
-#define MACON2_TFUNRST   0x01
 // ENC28J60 MACON3 Register Bit Definitions
 #define MACON3_PADCFG2   0x80
 #define MACON3_PADCFG1   0x40
@@ -394,7 +386,6 @@ byte ENC28J60::initialize (uint16_t size, const byte* macaddr, byte csPin) {
     writeReg(EPMM0, 0x303f);
     writeReg(EPMCS, 0xf7f9);
     writeRegByte(MACON1, MACON1_MARXEN|MACON1_TXPAUS|MACON1_RXPAUS);
-    writeRegByte(MACON2, 0x00);
     writeOp(ENC28J60_BIT_FIELD_SET, MACON3,
             MACON3_PADCFG0|MACON3_TXCRCEN|MACON3_FRMLNEN);
     writeReg(MAIPG, 0x0C12);


### PR DESCRIPTION
With thanks to @mindstormsking:
The MACON2 register I have removed does not exist. The datasheet of the ENC28J60 never mentions it or any of its bits, but states its address as Reserved. According to the datasheet "All reserved registers may be read, but their contents must not be changed.", so a write operation should not be performed.