### PR TITLE
Removed setting EIE_INTIE and EIE_PKTIE

### DIFF
--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -402,7 +402,6 @@ byte ENC28J60::initialize (uint16_t size, const byte* macaddr, byte csPin) {
     writeRegByte(MAADR0, macaddr[5]);
     writePhy(PHCON2, PHCON2_HDLDIS);
     SetBank(ECON1);
-    writeOp(ENC28J60_BIT_FIELD_SET, EIE, EIE_INTIE|EIE_PKTIE);
     writeOp(ENC28J60_BIT_FIELD_SET, ECON1, ECON1_RXEN);
 
     byte rev = readRegByte(EREVID);


### PR DESCRIPTION
Change suggested by @mindstormsking in #134:
The bits EIE_INTIE and EIE_PKTIE are pin-interrupt settings, while the pin-interrupt is not used by EtherCard.