### PR TITLE
Removed setting MACON1_TXPAUS and MACON1_RXPAUS

### DIFF
--- a/enc28j60.cpp
+++ b/enc28j60.cpp
@@ -388,7 +388,7 @@ byte ENC28J60::initialize (uint16_t size, const byte* macaddr, byte csPin) {
     writeRegByte(ERXFCON, ERXFCON_UCEN|ERXFCON_CRCEN|ERXFCON_PMEN|ERXFCON_BCEN);
     writeReg(EPMM0, 0x303f);
     writeReg(EPMCS, 0xf7f9);
-    writeRegByte(MACON1, MACON1_MARXEN|MACON1_TXPAUS|MACON1_RXPAUS);
+    writeRegByte(MACON1, MACON1_MARXEN);
     writeOp(ENC28J60_BIT_FIELD_SET, MACON3,
             MACON3_PADCFG0|MACON3_TXCRCEN|MACON3_FRMLNEN);
     writeReg(MAIPG, 0x0C12);


### PR DESCRIPTION
Change suggested by @mindstormsking in #134:
The bits MACON1_TXPAUS and MACON1_RXPAUS are used only in full-duplex mode, while according to all other settings, half-duplex mode is used.