### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,48 +6,48 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Block                          KEYWORD1
-BufferFiller                   KEYWORD1
-ENC28J60                       KEYWORD1
-EtherCard                      KEYWORD1
-Ethernet                       KEYWORD1
-Stash                          KEYWORD1
-StashHeader                    KEYWORD1
+Block	KEYWORD1
+BufferFiller	KEYWORD1
+ENC28J60	KEYWORD1
+EtherCard	KEYWORD1
+Ethernet	KEYWORD1
+Stash	KEYWORD1
+StashHeader	KEYWORD1
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-emit_p                         KEYWORD2
-emit_raw                       KEYWORD2
-emit_raw_p                     KEYWORD2
-buffer                         KEYWORD2
-Ethernet                       KEYWORD2
-printIp                        KEYWORD2
-staticSetup                    KEYWORD2
-dhcpSetup                      KEYWORD2
-packetLoop                     KEYWORD2
-packetReceive                  KEYWORD2
-httpServerReply                KEYWORD2
-browseUrl                      KEYWORD2
-tcpOffset                      KEYWORD2
-tcpSend                        KEYWORD2
-tcpReply                       KEYWORD2
-dnsLookup                      KEYWORD2
-httpServerReply                KEYWORD2
-SerialPrint_P                  KEYWORD2
-copyIp                         KEYWORD2
-getIP_address                  KEYWORD2
-hisip                          KEYWORD2
-myip                           KEYWORD2
-gwip                           KEYWORD2
-mymask                         KEYWORD2
-dnsip                          KEYWORD2
-cleanup                        KEYWORD2
-freeCount                      KEYWORD2
-extract                        KEYWORD2
-save                           KEYWORD2
-size                           KEYWORD2
+emit_p	KEYWORD2
+emit_raw	KEYWORD2
+emit_raw_p	KEYWORD2
+buffer	KEYWORD2
+Ethernet	KEYWORD2
+printIp	KEYWORD2
+staticSetup	KEYWORD2
+dhcpSetup	KEYWORD2
+packetLoop	KEYWORD2
+packetReceive	KEYWORD2
+httpServerReply	KEYWORD2
+browseUrl	KEYWORD2
+tcpOffset	KEYWORD2
+tcpSend	KEYWORD2
+tcpReply	KEYWORD2
+dnsLookup	KEYWORD2
+httpServerReply	KEYWORD2
+SerialPrint_P	KEYWORD2
+copyIp	KEYWORD2
+getIP_address	KEYWORD2
+hisip	KEYWORD2
+myip	KEYWORD2
+gwip	KEYWORD2
+mymask	KEYWORD2
+dnsip	KEYWORD2
+cleanup	KEYWORD2
+freeCount	KEYWORD2
+extract	KEYWORD2
+save	KEYWORD2
+size	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords