### PR TITLE
Missing include

### DIFF
--- a/src/bufferfiller.cpp
+++ b/src/bufferfiller.cpp
@@ -1,4 +1,5 @@
 #include "bufferfiller.h"
+#include <avr/eeprom.h>
 
 void BufferFiller::emit_p(const char* fmt PROGMEM, ...) {
     va_list ap;


### PR DESCRIPTION
Ethercard failed to compile without this header (Ubuntu 18.10)