### PR TITLE
rewrite EtherCard::parseIp

### DIFF
--- a/src/EtherCard.h
+++ b/src/EtherCard.h
@@ -459,7 +459,7 @@ public:
     *     @param  str Pointer to string to parse
     *     @return <i>uint8_t</i> 0 on success
     */
-    static uint8_t parseIp(uint8_t *bytestr,char *str);
+    static uint8_t parseIp(uint8_t *bytestr, const char *str);
 
     /**   @brief  Convert a byte array to a human readable display string
     *     @param  resultstr Pointer to a buffer to hold the resulting null terminated string

--- a/src/webutil.cpp
+++ b/src/webutil.cpp
@@ -149,35 +149,27 @@ void EtherCard::urlEncode (char *str,char *urlbuf)
 }
 
 // parse a string and extract the IP to bytestr
-uint8_t EtherCard::parseIp (uint8_t *bytestr,char *str)
+uint8_t EtherCard::parseIp (uint8_t *bytestr, const char *str)
 {
-    char *sptr;
-    uint8_t i=0;
-    sptr=NULL;
-    while(i<IP_LEN) {
-        bytestr[i]=0;
-        i++;
-    }
-    i=0;
-    while(*str && i<IP_LEN) {
-        // if a number then start
-        if (sptr==NULL && isdigit(*str)) {
-            sptr=str;
+    uint8_t res = 1;
+    for (uint8_t i = 0; i < IP_LEN; ++i)
+    {
+        bytestr[i] = atoi(str) & 0xFF;
+        for (; *str != '\0'; ++str)
+        {
+            if (*str == '.')
+            {
+                ++str;
+                break;
+            }
+            else if (!isdigit(*str))
+            {
+                res = 0;
+                break;
+            }
         }
-        if (*str == '.') {
-            *str ='\0';
-            bytestr[i]=(atoi(sptr)&0xff);
-            i++;
-            sptr=NULL;
-        }
-        str++;
     }
-    *str ='\0';
-    if (i==IP_LEN-1) {
-        bytestr[i]=(atoi(sptr)&0xff);
-        return(0);
-    }
-    return(1);
+    return res;
 }
 
 // take a byte string and convert it to a human readable display string  (base is 10 for ip and 16 for mac addr), len is 4[IP_LEN] for IP addr and 6[ETHER_LEN] for mac.


### PR DESCRIPTION
This rewrite save 40 bytes with CC_VERSION = 5.4.0 (avr-gcc)

As major change the input is used as a const char *. Always avoid to modify user input.

With old API you could not parse the string more than one as input string was updated with null bytes. Then output was always null IP.