### PR TITLE
Examples

### DIFF
--- a/examples/SSDP/SSDP.ino
+++ b/examples/SSDP/SSDP.ino
@@ -7,14 +7,10 @@ const char SSDP_NOTIFY[] PROGMEM = "NOTIFY * HTTP/1.1\r\nHOST: 239.255.255.250:1
 //  in XML_DESCRIP // <friendlyName>Arduino</friendlyName> // declare the name of the service here Arduino
 //  in XML_DESCRIP // <presentationURL>/</presentationURL> // adress of the page who would opened on service double click ,you could use http://ip  but if you use dhcp it's better so and dont wase memory
 // this is the entire protocol, but you can try to use SSDP_NOTIFY as SSDP_RESPONSE with most systems will work and you can free a bit of flash mem.
-static byte myip[] = {
-  192,168,0,67 };
-static byte gwip[] = {
-  192,168,0,250 };
-static byte ssdp[] = {
-  239,255,255,250 };
-static byte mymac[] = {
-  0x74,0x99,0x69,0x2D,0x30,0x40 }; // if you change it you must update SSDP_RESPONSE and XML_DESCRIP
+static byte myip[] = { 192,168,0,67 };
+static byte gwip[] = { 192,168,0,250 };
+static byte ssdp[] = { 239,255,255,250 };
+static byte mymac[] = { 0x74,0x99,0x69,0x2D,0x30,0x40 }; // if you change it you must update SSDP_RESPONSE and XML_DESCRIP
 byte Ethernet::buffer[750]; // tcp ip send and receive buffer
 unsigned long timer=9999;
 const char pageA[] PROGMEM =

--- a/examples/SSDP/SSDP.ino
+++ b/examples/SSDP/SSDP.ino
@@ -48,6 +48,10 @@ const char pageD[] PROGMEM =
 "</em></p>"
 ;
 
+void ssdpresp();
+void addip(int udppos);
+void ssdpnotify();
+
 void setup(){
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
   ether.begin(sizeof Ethernet::buffer, mymac, SS);

--- a/examples/getStaticIP/getStaticIP.ino
+++ b/examples/getStaticIP/getStaticIP.ino
@@ -11,6 +11,8 @@
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 // ethernet interface ip address
 static byte myip[] = { 192,168,1,203 };
+// ethernet interface ip netmask
+static byte mask[] = { 255,255,255,0 };
 // gateway ip address
 static byte gwip[] = { 192,168,1,1 };
 // remote website ip address and port
@@ -37,7 +39,7 @@ void setup () {
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println( "Failed to access Ethernet controller");
 
-  ether.staticSetup(myip, gwip);
+  ether.staticSetup(myip, gwip, NULL, mask);
 
   ether.copyIp(ether.hisip, hisip);
   ether.printIp("Server: ", ether.hisip);

--- a/examples/getViaDNS/getViaDNS.ino
+++ b/examples/getViaDNS/getViaDNS.ino
@@ -11,6 +11,8 @@
 static byte mymac[] = { 0x74,0x69,0x69,0x2D,0x30,0x31 };
 // ethernet interface ip address
 static byte myip[] = { 192,168,1,203 };
+// ethernet interface ip netmask
+static byte mask[] = { 255,255,255,0 };
 // gateway ip address
 static byte gwip[] = { 192,168,1,1 };
 // remote website name
@@ -35,7 +37,7 @@ void setup () {
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println( "Failed to access Ethernet controller");
 
-  ether.staticSetup(myip, gwip);
+  ether.staticSetup(myip, gwip, NULL, mask);
 
   if (!ether.dnsLookup(website))
     Serial.println("DNS failed");

--- a/examples/noipClient/noipClient.ino
+++ b/examples/noipClient/noipClient.ino
@@ -48,6 +48,12 @@ static uint32_t request_timer;
 int attempt;
 Stash stash;
 
+void checkPublicIP();
+void checkPublicIPResponse();
+void updateNoIP();
+void checkNoIPResponse();
+void SerialPrint_P(const char* str PROGMEM);
+
 void setup () {
 
     Serial.begin(57600);

--- a/examples/ntpClient/ntpClient.ino
+++ b/examples/ntpClient/ntpClient.ino
@@ -25,6 +25,9 @@ const unsigned int NTP_LOCALPORT = 8888;             // Local UDP port to use
 const unsigned int NTP_PACKET_SIZE = 48;             // NTP time stamp is in the first 48 bytes of the message
 byte Ethernet::buffer[350];                          // Buffer must be 350 for DHCP to work
 
+void sendNTPpacket(const uint8_t* remoteAddress);
+void udpReceiveNtpPacket(uint16_t dest_port, uint8_t src_ip[IP_LEN], uint16_t src_port, const char *packetBuffer, uint16_t len);
+
 void setup() {
   Serial.begin(9600);
   Serial.println(F("\n[EtherCard NTP Client]"));

--- a/examples/rbbb_server/rbbb_server.ino
+++ b/examples/rbbb_server/rbbb_server.ino
@@ -13,6 +13,8 @@ byte Ethernet::buffer[500];
 BufferFiller bfill;
 
 void setup () {
+  Serial.begin(57600);
+  Serial.println(F("\n[RBBB Server]"));
   // Change 'SS' to your Slave Select pin, if you arn't using the default pin
   if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
     Serial.println(F("Failed to access Ethernet controller"));

--- a/examples/thingspeak/thingspeak.ino
+++ b/examples/thingspeak/thingspeak.ino
@@ -29,6 +29,7 @@ byte session;
 //timing variable
 int res = 100; // was 0
 
+void initialize_ethernet(void);
 
 
 void setup () {

--- a/examples/xively/xively.ino
+++ b/examples/xively/xively.ino
@@ -25,6 +25,7 @@ byte session;
 //timing variable
 int res = 0;
 
+void initialize_ethernet(void);
 
 
 void setup () {


### PR DESCRIPTION
I've fixed examples that could not be build on my env. Mostly function declared after used in example files.

For some other tests I've standardize the serial baudrate, IP/MAC/netmask definition just to allow my validation script to automaticaly replace values by expected ones for my env