### PR TITLE
Moved the setup() and loop() functions to the bottom of all the examples

### DIFF
--- a/examples/JeeUdp/JeeUdp.ino
+++ b/examples/JeeUdp/JeeUdp.ino
@@ -75,19 +75,6 @@ return (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval);
 }
 #endif
 
-void setup (){
-  Serial.begin(57600);
-  Serial.println("\n[JeeUdp]");
-  loadConfig();
-
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
-    Serial.println( "Failed to access Ethernet controller");
-  if (!ether.dhcpSetup())
-    Serial.println("DHCP failed");
-  ether.printIp("IP: ", ether.myip);
-}
-
 const char okHeader[] PROGMEM =
   "HTTP/1.0 200 OK\r\n"
   "Content-Type: text/html\r\n"
@@ -266,6 +253,19 @@ static void forwardToUDP () {
 #if SERIAL
   Serial.println("UDP sent");
 #endif
+}
+
+void setup (){
+  Serial.begin(57600);
+  Serial.println("\n[JeeUdp]");
+  loadConfig();
+
+  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+    Serial.println( "Failed to access Ethernet controller");
+  if (!ether.dhcpSetup())
+    Serial.println("DHCP failed");
+  ether.printIp("IP: ", ether.myip);
 }
 
 void loop (){

--- a/examples/etherNode/etherNode.ino
+++ b/examples/etherNode/etherNode.ino
@@ -75,23 +75,6 @@ static int freeRam () {
 }
 #endif
 
-void setup(){
-#if SERIAL
-    Serial.begin(57600);
-    Serial.println("\n[etherNode]");
-#endif
-    loadConfig();
-
-    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-    if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
-      Serial.println( "Failed to access Ethernet controller");
-    if (!ether.dhcpSetup())
-      Serial.println("DHCP failed");
-#if SERIAL
-    ether.printIp("IP: ", ether.myip);
-#endif
-}
-
 const char okHeader[] PROGMEM =
     "HTTP/1.0 200 OK\r\n"
     "Content-Type: text/html\r\n"
@@ -224,6 +207,23 @@ static void sendPage(const char* data, BufferFiller& buf) {
           "</p>"
           "<input type=submit value=Send>"
         "</form>"), okHeader);
+}
+
+void setup(){
+#if SERIAL
+    Serial.begin(57600);
+    Serial.println("\n[etherNode]");
+#endif
+    loadConfig();
+
+    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+    if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+      Serial.println( "Failed to access Ethernet controller");
+    if (!ether.dhcpSetup())
+      Serial.println("DHCP failed");
+#if SERIAL
+    ether.printIp("IP: ", ether.myip);
+#endif
 }
 
 void loop(){

--- a/examples/multipacketSD/multipacketSD.ino
+++ b/examples/multipacketSD/multipacketSD.ino
@@ -22,45 +22,6 @@ unsigned long cur;
 unsigned long pos;
 byte res;
 
-void setup() {
-  // Initialize serial communication at 115200 baud
-  Serial.begin(115200);
-  // Initialize tinyFAT
-  // You might need to select a lower speed than the default SPISPEED_HIGH
-    file.setSSpin(4);
-  res=file.initFAT(0);
-  if (res==NO_ERROR)    Serial.println("SD started");
-
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  ether.begin(sizeof Ethernet::buffer, mymac , SS);
-  ether.staticSetup(myip, gwip);
-  Serial.println("ETH started");
-}
-
-void loop()
-{
-   wait:
-    pos = ether.packetLoop(ether.packetReceive());// check if valid tcp data is received
-    if (pos) {
-        char* data = (char *) Ethernet::buffer + pos;
-        cur=0;
-        if (strncmp("GET / ", data, 6) == 0) {// nothing specified
-          sendfiles("index.htm");
-          goto wait;
-          }
-        if (strncmp("GET /", data, 5) == 0) { // serve anything on sd card
-            int i =0;
-            char temp[15]=""; // here will be the name of requested file
-            while (data[i+5]!=32) {temp[i]=data[i+5];i++;}//search the end
-            sendfiles((char*) temp);
-            goto wait;
-          }
-       not_found();
-
-  }
-
-}
-
 void not_found() { //content not found
   cur=0;
   streamfile ("404.hea",TCP_FLAGS_FIN_V);
@@ -128,4 +89,45 @@ if (i<33) Serial.print(".");
   }
   Serial.println(" ");
   */
+}
+
+
+void setup()
+{
+  // Initialize serial communication at 115200 baud
+  Serial.begin(115200);
+  // Initialize tinyFAT
+  // You might need to select a lower speed than the default SPISPEED_HIGH
+    file.setSSpin(4);
+  res=file.initFAT(0);
+  if (res==NO_ERROR)    Serial.println("SD started");
+
+  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  ether.begin(sizeof Ethernet::buffer, mymac , SS);
+  ether.staticSetup(myip, gwip);
+  Serial.println("ETH started");
+}
+
+void loop()
+{
+   wait:
+    pos = ether.packetLoop(ether.packetReceive());// check if valid tcp data is received
+    if (pos) {
+        char* data = (char *) Ethernet::buffer + pos;
+        cur=0;
+        if (strncmp("GET / ", data, 6) == 0) {// nothing specified
+          sendfiles("index.htm");
+          goto wait;
+          }
+        if (strncmp("GET /", data, 5) == 0) { // serve anything on sd card
+            int i =0;
+            char temp[15]=""; // here will be the name of requested file
+            while (data[i+5]!=32) {temp[i]=data[i+5];i++;}//search the end
+            sendfiles((char*) temp);
+            goto wait;
+          }
+       not_found();
+
+  }
+
 }

--- a/examples/noipClient/noipClient.ino
+++ b/examples/noipClient/noipClient.ino
@@ -48,79 +48,6 @@ static uint32_t request_timer;
 int attempt;
 Stash stash;
 
-void setup () {
-
-    Serial.begin(57600);
-    Serial.println(F("NoIP Client Demo"));
-    Serial.println();
-
-    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-    if (!ether.begin(sizeof Ethernet::buffer, mymac, SS))
-        Serial.println(F( "Failed to access Ethernet controller"));
-    else
-        Serial.println(F("Ethernet controller initialized"));
-    Serial.println();
-
-    if (!ether.dhcpSetup())
-        Serial.println(F("Failed to get configuration from DHCP"));
-    else
-        Serial.println(F("DHCP configuration done"));
-
-    ether.printIp("IP Address:\t", ether.myip);
-    ether.printIp("Netmask:\t", ether.netmask);
-    ether.printIp("Gateway:\t", ether.gwip);
-    Serial.println();
-
-    actual_status = STATUS_IDLE;
-    attempt = 0;
-
-    // Resolve IP for getIP_web and noIP_web
-    // and store them into global variables
-    if (!ether.dnsLookup(getIP_web)) {
-        Serial.print(F("Unable to resolve IP for "));
-        SerialPrint_P(getIP_web);
-        actual_status = STATUS_ERROR;
-    } else {
-        ether.copyIp(getIP_address, ether.hisip);
-        SerialPrint_P(getIP_web);
-        ether.printIp(" resolved to:\t", ether.hisip);
-    }
-    if (!ether.dnsLookup(noIP_web)) {
-        Serial.print(F("Unable to resolve IP for "));
-        SerialPrint_P(noIP_web);
-        actual_status = STATUS_ERROR;
-    } else {
-        ether.copyIp(noIP_address, ether.hisip);
-        SerialPrint_P(noIP_web);
-        ether.printIp(" resolved to:\t", ether.hisip);
-    }
-
-    Serial.println();
-}
-
-
-void loop() {
-
-    ether.packetLoop(ether.packetReceive());
-
-    // FSM
-    switch(actual_status) {
-
-    case STATUS_IDLE:
-        checkPublicIP();
-        break;
-    case STATUS_WAITING_FOR_PUBLIC_IP:
-        checkPublicIPResponse();
-        break;
-    case STATUS_NOIP_NEEDS_UPDATE:
-        updateNoIP();
-        break;
-    case STATUS_WAITING_FOR_NOIP:
-        checkNoIPResponse();
-        break;
-    }
-}
-
 void checkPublicIP() {
 
     if(millis() > check_ip_timer) {
@@ -277,4 +204,77 @@ void checkNoIPResponse() {
 
 void SerialPrint_P(const char* str PROGMEM) {
     for (uint8_t c; (c = pgm_read_byte(str)); str++) Serial.write(c);
+}
+
+void setup () {
+
+    Serial.begin(57600);
+    Serial.println(F("NoIP Client Demo"));
+    Serial.println();
+
+    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+    if (!ether.begin(sizeof Ethernet::buffer, mymac, SS))
+        Serial.println(F( "Failed to access Ethernet controller"));
+    else
+        Serial.println(F("Ethernet controller initialized"));
+    Serial.println();
+
+    if (!ether.dhcpSetup())
+        Serial.println(F("Failed to get configuration from DHCP"));
+    else
+        Serial.println(F("DHCP configuration done"));
+
+    ether.printIp("IP Address:\t", ether.myip);
+    ether.printIp("Netmask:\t", ether.netmask);
+    ether.printIp("Gateway:\t", ether.gwip);
+    Serial.println();
+
+    actual_status = STATUS_IDLE;
+    attempt = 0;
+
+    // Resolve IP for getIP_web and noIP_web
+    // and store them into global variables
+    if (!ether.dnsLookup(getIP_web)) {
+        Serial.print(F("Unable to resolve IP for "));
+        SerialPrint_P(getIP_web);
+        actual_status = STATUS_ERROR;
+    } else {
+        ether.copyIp(getIP_address, ether.hisip);
+        SerialPrint_P(getIP_web);
+        ether.printIp(" resolved to:\t", ether.hisip);
+    }
+    if (!ether.dnsLookup(noIP_web)) {
+        Serial.print(F("Unable to resolve IP for "));
+        SerialPrint_P(noIP_web);
+        actual_status = STATUS_ERROR;
+    } else {
+        ether.copyIp(noIP_address, ether.hisip);
+        SerialPrint_P(noIP_web);
+        ether.printIp(" resolved to:\t", ether.hisip);
+    }
+
+    Serial.println();
+}
+
+
+void loop() {
+
+    ether.packetLoop(ether.packetReceive());
+
+    // FSM
+    switch(actual_status) {
+
+    case STATUS_IDLE:
+        checkPublicIP();
+        break;
+    case STATUS_WAITING_FOR_PUBLIC_IP:
+        checkPublicIPResponse();
+        break;
+    case STATUS_NOIP_NEEDS_UPDATE:
+        updateNoIP();
+        break;
+    case STATUS_WAITING_FOR_NOIP:
+        checkNoIPResponse();
+        break;
+    }
 }

--- a/examples/ntpClient/ntpClient.ino
+++ b/examples/ntpClient/ntpClient.ino
@@ -25,38 +25,6 @@ const unsigned int NTP_LOCALPORT = 8888;             // Local UDP port to use
 const unsigned int NTP_PACKET_SIZE = 48;             // NTP time stamp is in the first 48 bytes of the message
 byte Ethernet::buffer[350];                          // Buffer must be 350 for DHCP to work
 
-void setup() {
-  Serial.begin(9600);
-  Serial.println(F("\n[EtherCard NTP Client]"));
-
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, myMac, SS) == 0)
-    Serial.println(F("Failed to access Ethernet controller"));
-  if (!ether.dhcpSetup())
-    Serial.println(F("DHCP failed"));
-
-  ether.printIp("IP:  ", ether.myip);
-  ether.printIp("GW:  ", ether.gwip);
-  ether.printIp("DNS: ", ether.dnsip);
-
-  if (!ether.dnsLookup(NTP_REMOTEHOST))
-    Serial.println("DNS failed");
-
-  uint8_t ntpIp[IP_LEN];
-  ether.copyIp(ntpIp, ether.hisip);
-  ether.printIp("NTP: ", ntpIp);
-
-  ether.udpServerListenOnPort(&udpReceiveNtpPacket, NTP_LOCALPORT);
-  Serial.println("Started listening for response.");
-
-  sendNTPpacket(ntpIp);
-}
-
-void loop() {
-  // this must be called for ethercard functions to work.
-  ether.packetLoop(ether.packetReceive());
-}
-
 // send an NTP request to the time server at the given address
 void sendNTPpacket(const uint8_t* remoteAddress) {
   // buffer to hold outgoing packet
@@ -101,3 +69,35 @@ void udpReceiveNtpPacket(uint16_t dest_port, uint8_t src_ip[IP_LEN], uint16_t sr
   Serial.println(epoch);
 }
 
+
+void setup() {
+  Serial.begin(9600);
+  Serial.println(F("\n[EtherCard NTP Client]"));
+
+  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  if (ether.begin(sizeof Ethernet::buffer, myMac, SS) == 0)
+    Serial.println(F("Failed to access Ethernet controller"));
+  if (!ether.dhcpSetup())
+    Serial.println(F("DHCP failed"));
+
+  ether.printIp("IP:  ", ether.myip);
+  ether.printIp("GW:  ", ether.gwip);
+  ether.printIp("DNS: ", ether.dnsip);
+
+  if (!ether.dnsLookup(NTP_REMOTEHOST))
+    Serial.println("DNS failed");
+
+  uint8_t ntpIp[IP_LEN];
+  ether.copyIp(ntpIp, ether.hisip);
+  ether.printIp("NTP: ", ntpIp);
+
+  ether.udpServerListenOnPort(&udpReceiveNtpPacket, NTP_LOCALPORT);
+  Serial.println("Started listening for response.");
+
+  sendNTPpacket(ntpIp);
+}
+
+void loop() {
+  // this must be called for ethercard functions to work.
+  ether.packetLoop(ether.packetReceive());
+}

--- a/examples/rbbb_server/rbbb_server.ino
+++ b/examples/rbbb_server/rbbb_server.ino
@@ -12,15 +12,6 @@ static byte myip[] = { 192,168,1,203 };
 byte Ethernet::buffer[500];
 BufferFiller bfill;
 
-void setup () {
-  Serial.begin(57600);
-  Serial.println(F("\n[RBBB Server]"));
-  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
-    Serial.println(F("Failed to access Ethernet controller"));
-  ether.staticSetup(myip);
-}
-
 static word homePage() {
   long t = millis() / 1000;
   word h = t / 3600;
@@ -37,6 +28,15 @@ static word homePage() {
     "<h1>$D$D:$D$D:$D$D</h1>"),
       h/10, h%10, m/10, m%10, s/10, s%10);
   return bfill.position();
+}
+
+void setup () {
+  Serial.begin(57600);
+  Serial.println(F("\n[RBBB Server]"));
+  // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+  if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0)
+    Serial.println(F("Failed to access Ethernet controller"));
+  ether.staticSetup(myip);
 }
 
 void loop () {

--- a/examples/thingspeak/thingspeak.ino
+++ b/examples/thingspeak/thingspeak.ino
@@ -30,6 +30,41 @@ byte session;
 int res = 100; // was 0
 
 
+void initialize_ethernet(void){
+  for(;;){ // keep trying until you succeed
+    //Reinitialize ethernet module
+    //pinMode(5, OUTPUT);  // do notknow what this is for, i ve got something elso on pin5
+    //Serial.println("Reseting Ethernet...");
+    //digitalWrite(5, LOW);
+    //delay(1000);
+    //digitalWrite(5, HIGH);
+    //delay(500);
+
+    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+    if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0){
+      Serial.println( "Failed to access Ethernet controller");
+      continue;
+    }
+
+    if (!ether.dhcpSetup()){
+      Serial.println("DHCP failed");
+      continue;
+    }
+
+    ether.printIp("IP:  ", ether.myip);
+    ether.printIp("GW:  ", ether.gwip);
+    ether.printIp("DNS: ", ether.dnsip);
+
+    if (!ether.dnsLookup(website))
+      Serial.println("DNS failed");
+
+    ether.printIp("SRV: ", ether.hisip);
+
+    //reset init value
+    res = 180;
+    break;
+  }
+}
 
 void setup () {
   Serial.begin(9600);
@@ -38,7 +73,6 @@ void setup () {
   //Initialize Ethernet
   initialize_ethernet();
 }
-
 
 void loop () {
   //if correct answer is not received then re-initialize ethernet module
@@ -53,8 +87,7 @@ void loop () {
   //200 res = 10 seconds (50ms each res)
   if (res == 200) {
 
-
-    //Generate random info
+    // Generate random info
     float demo = random(0,500);
     word one = random(0,500);
     String msje;
@@ -113,39 +146,3 @@ void loop () {
 }
 
 
-
-void initialize_ethernet(void){
-  for(;;){ // keep trying until you succeed
-    //Reinitialize ethernet module
-    //pinMode(5, OUTPUT);  // do notknow what this is for, i ve got something elso on pin5
-    //Serial.println("Reseting Ethernet...");
-    //digitalWrite(5, LOW);
-    //delay(1000);
-    //digitalWrite(5, HIGH);
-    //delay(500);
-
-    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-    if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0){
-      Serial.println( "Failed to access Ethernet controller");
-      continue;
-    }
-
-    if (!ether.dhcpSetup()){
-      Serial.println("DHCP failed");
-      continue;
-    }
-
-    ether.printIp("IP:  ", ether.myip);
-    ether.printIp("GW:  ", ether.gwip);
-    ether.printIp("DNS: ", ether.dnsip);
-
-    if (!ether.dnsLookup(website))
-      Serial.println("DNS failed");
-
-    ether.printIp("SRV: ", ether.hisip);
-
-    //reset init value
-    res = 180;
-    break;
-  }
-}

--- a/examples/xively/xively.ino
+++ b/examples/xively/xively.ino
@@ -25,6 +25,42 @@ byte session;
 //timing variable
 int res = 0;
 
+void initialize_ethernet(void){
+  for(;;){ // keep trying until you succeed
+    //Reinitialize ethernet module
+    pinMode(5, OUTPUT);
+    Serial.println("Reseting Ethernet...");
+    digitalWrite(5, LOW);
+    delay(1000);
+    digitalWrite(5, HIGH);
+    delay(500);
+
+    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
+    if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0){
+      Serial.println( "Failed to access Ethernet controller");
+      continue;
+    }
+
+    if (!ether.dhcpSetup()){
+      Serial.println("DHCP failed");
+      continue;
+    }
+
+    ether.printIp("IP:  ", ether.myip);
+    ether.printIp("GW:  ", ether.gwip);
+    ether.printIp("DNS: ", ether.dnsip);
+
+    if (!ether.dnsLookup(website))
+      Serial.println("DNS failed");
+
+    ether.printIp("SRV: ", ether.hisip);
+
+    //reset init value
+    res = 0;
+    break;
+  }
+}
+
 
 
 void setup () {
@@ -101,42 +137,4 @@ void loop () {
      Serial.println(reply);
    }
    delay(50);
-}
-
-
-
-void initialize_ethernet(void){
-  for(;;){ // keep trying until you succeed
-    //Reinitialize ethernet module
-    pinMode(5, OUTPUT);
-    Serial.println("Reseting Ethernet...");
-    digitalWrite(5, LOW);
-    delay(1000);
-    digitalWrite(5, HIGH);
-    delay(500);
-
-    // Change 'SS' to your Slave Select pin, if you arn't using the default pin
-    if (ether.begin(sizeof Ethernet::buffer, mymac, SS) == 0){
-      Serial.println( "Failed to access Ethernet controller");
-      continue;
-    }
-
-    if (!ether.dhcpSetup()){
-      Serial.println("DHCP failed");
-      continue;
-    }
-
-    ether.printIp("IP:  ", ether.myip);
-    ether.printIp("GW:  ", ether.gwip);
-    ether.printIp("DNS: ", ether.dnsip);
-
-    if (!ether.dnsLookup(website))
-      Serial.println("DNS failed");
-
-    ether.printIp("SRV: ", ether.hisip);
-
-    //reset init value
-    res = 0;
-    break;
-  }
 }


### PR DESCRIPTION
I have moved all the setup() and loop() functions to the bottoms of the examples.
This is so that they compile (outside of Arduino) without any errors, or requiring function prototypes.

See also #354
