### PR TITLE
Document ARP cache issue and workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Currently the library does not have a local network ARP cache implemented. This 
  * The only ARP lookup it does is for the gateway address.
  * You cannot send frames to local network devices network except via a gateway.
 
-If you are wondering why your local UDP packets are not being received, this is why! (See #59, #181, #269, #309, #351, #368).
+If you are wondering why your local UDP packets are not being received, this is why! (See [#59](https://github.com/njh/EtherCard/issues/59), [#181](https://github.com/njh/EtherCard/issues/181), [#269](https://github.com/njh/EtherCard/issues/269), [#309](https://github.com/njh/EtherCard/issues/309), [#351](https://github.com/njh/EtherCard/issues/351), [#368](https://github.com/njh/EtherCard/issues/368)).
 
 The general workaround is to use a gateway and send only to devices non-local network address ranges.
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ if(!ether.dnsLookup("google.com"))
 ether.printIp("Server: ", ether.hisip); // Result of DNS lookup is placed in the hisip member of EtherCard.
 ```
 
+## Gotchas
+
+Currently the library does not have a local network ARP cache implemented. This means:
+ * The only ARP lookup it does is for the gateway address.
+ * You cannot send frames to local network devices network except via a gateway.
+
+If you are wondering why your local UDP packets are not being received, this is why! (See #59, #181, #269, #309, #351, #368).
+
+The general workaround is to use a gateway and send only to devices non-local network address ranges.
+
 
 ## Related Work
 

--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ ether.printIp("Server: ", ether.hisip); // Result of DNS lookup is placed in the
 
 ## Gotchas
 
-Currently the library does not have a local network ARP cache implemented. This means:
+Currently the library does not have a local network ARP cache implemented. This means if sending UDP:
  * The only ARP lookup it does is for the gateway address.
- * You cannot send frames to local network devices network except via a gateway.
+ * You cannot send UDP frames except via a gateway.
 
 If you are wondering why your local UDP packets are not being received, this is why! (See [#59](https://github.com/njh/EtherCard/issues/59), [#181](https://github.com/njh/EtherCard/issues/181), [#269](https://github.com/njh/EtherCard/issues/269), [#309](https://github.com/njh/EtherCard/issues/309), [#351](https://github.com/njh/EtherCard/issues/351), [#368](https://github.com/njh/EtherCard/issues/368)).
 
-The general workaround is to use a gateway and send only to devices non-local network address ranges.
+The general workaround is to use a gateway and send UDP packets only to devices non-local network addresses.
 
 
 ## Related Work

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Currently the library does not have a local network ARP cache implemented. This 
 
 If you are wondering why your local UDP packets are not being received, this is why! (See [#59](https://github.com/njh/EtherCard/issues/59), [#181](https://github.com/njh/EtherCard/issues/181), [#269](https://github.com/njh/EtherCard/issues/269), [#309](https://github.com/njh/EtherCard/issues/309), [#351](https://github.com/njh/EtherCard/issues/351), [#368](https://github.com/njh/EtherCard/issues/368)).
 
-The general workaround is to use a gateway and send UDP packets only to devices non-local network addresses.
+The general workaround is to use a gateway and send UDP packets only to non-local network addresses.
 
 
 ## Related Work


### PR DESCRIPTION
A lot of people hit this so a front and center warning with suggested workaround would seem appropriate.