### PR TITLE
CI: use python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
-    - "2.7"
+    - "3.6"
+
+dist: bionic
 
 # Cache PlatformIO packages using Travis CI container-based infrastructure
 sudo: false


### PR DESCRIPTION
[python 2.7 is dead](https://www.python.org/doc/sunset-python-2/)
python 3.6 is supported until 2021-12
It would be better to move to python 3.8 right away,
but since it is not installed by default in Travis,
having to download it in each job would make the builds significantly slower.

---
- 2.7 on xenial: [total time ~16 minutes](https://travis-ci.com/github/njh/EtherCard/builds/171198189)
- 3.8 on xenial: (#392) [total time ~25 minutes](https://travis-ci.com/github/njh/EtherCard/builds/178136234)
- 3.6 on bionic: [total time ~19 minutes](https://travis-ci.com/github/njh/EtherCard/builds/178137198)

Note the builds against python 3.8 and 3.6, contrary to the build against 2.7, did not use the platformio cache since it was the first time they ran. Subsequent builds will be faster.