### PR TITLE
replace SERIAL macro with SERIAL_PRINT

### DIFF
--- a/examples/JeeUdp/JeeUdp.ino
+++ b/examples/JeeUdp/JeeUdp.ino
@@ -10,8 +10,8 @@
 #include <JeeLib.h>
 #include <avr/eeprom.h>
 
-#define DEBUG   1   // set to 1 to display free RAM on web page
-#define SERIAL  1   // set to 1 to show incoming requests on serial port
+#define DEBUG         1   // set to 1 to display free RAM on web page
+#define SERIAL_PRINT  1   // set to 1 to show incoming requests on serial port
 
 #define CONFIG_EEPROM_ADDR ((byte*) 0x10)
 
@@ -177,7 +177,7 @@ static void sendPage (const char* data, BufferFiller& buf) {
         outBuf[outCount] = 10 * outBuf[outCount] + (*p - '0');
       ++outCount;
     }
-#if SERIAL
+#if SERIAL_PRINT
     Serial.print("Send to ");
     Serial.print(outDest, DEC);
     Serial.print(':');
@@ -250,7 +250,7 @@ static void forwardToUDP () {
   collectPayload(0x0006);
 
   ether.sendUdp ((char*) collBuf, collPos, 23456, destIp, config.port);
-#if SERIAL
+#if SERIAL_PRINT
   Serial.println("UDP sent");
 #endif
 }
@@ -275,7 +275,7 @@ void loop (){
   if (pos) {
     bfill = ether.tcpOffset();
     char* data = (char *) Ethernet::buffer + pos;
-#if SERIAL
+#if SERIAL_PRINT
     Serial.println(data);
 #endif
     // receive buf hasn't been clobbered by reply yet
@@ -306,7 +306,7 @@ void loop (){
     msgs_rcvd = (msgs_rcvd + 1) % 10000;
 
     if (RF12_WANTS_ACK && !config.collect) {
-#if SERIAL
+#if SERIAL_PRINT
       Serial.println(" -> ack");
 #endif
       rf12_sendStart(RF12_ACK_REPLY);

--- a/examples/etherNode/etherNode.ino
+++ b/examples/etherNode/etherNode.ino
@@ -13,8 +13,8 @@
 #include <JeeLib.h>
 #include <avr/eeprom.h>
 
-#define DEBUG   1   // set to 1 to display free RAM on web page
-#define SERIAL  0   // set to 1 to show incoming requests on serial port
+#define DEBUG         1   // set to 1 to display free RAM on web page
+#define SERIAL_PRINT  0   // set to 1 to show incoming requests on serial port
 
 #define CONFIG_EEPROM_ADDR ((byte*) 0x10)
 
@@ -179,7 +179,7 @@ static void sendPage(const char* data, BufferFiller& buf) {
                 outBuf[outCount] = 10 * outBuf[outCount] + (*p - '0');
             ++outCount;
         }
-#if SERIAL
+#if SERIAL_PRINT
         Serial.print("Send to ");
         Serial.print(outDest, DEC);
         Serial.print(':');
@@ -210,7 +210,7 @@ static void sendPage(const char* data, BufferFiller& buf) {
 }
 
 void setup(){
-#if SERIAL
+#if SERIAL_PRINT
     Serial.begin(57600);
     Serial.println("\n[etherNode]");
 #endif
@@ -221,7 +221,7 @@ void setup(){
       Serial.println( "Failed to access Ethernet controller");
     if (!ether.dhcpSetup())
       Serial.println("DHCP failed");
-#if SERIAL
+#if SERIAL_PRINT
     ether.printIp("IP: ", ether.myip);
 #endif
 }
@@ -233,7 +233,7 @@ void loop(){
     if (pos) {
         bfill = ether.tcpOffset();
         char* data = (char *) Ethernet::buffer + pos;
-#if SERIAL
+#if SERIAL_PRINT
         Serial.println(data);
 #endif
         // receive buf hasn't been clobbered by reply yet
@@ -264,7 +264,7 @@ void loop(){
         msgs_rcvd = (msgs_rcvd + 1) % 10000;
 
         if (RF12_WANTS_ACK && !config.collect) {
-#if SERIAL
+#if SERIAL_PRINT
             Serial.println(" -> ack");
 #endif
             rf12_sendStart(RF12_ACK_REPLY);

--- a/src/tcpip.cpp
+++ b/src/tcpip.cpp
@@ -604,7 +604,7 @@ static uint16_t tcp_datafill_cb(uint8_t fd) {
     Stash::extract(0, len, EtherCard::tcpOffset());
     Stash::cleanup();
     EtherCard::tcpOffset()[len] = 0;
-#if SERIAL
+#if SERIAL_PRINT
     Serial.print("REQUEST: ");
     Serial.println(len);
     Serial.println((char*) EtherCard::tcpOffset());


### PR DESCRIPTION
SERIAL already is used by the [Arduino core](https://github.com/arduino/ArduinoCore-avr/blob/3055c1efa3c6980c864f661e6c8cc5d5ac773af4/cores/arduino/Arduino.h#L54) and causes a [compiler warning](https://travis-ci.com/github/njh/EtherCard/jobs/367604836#L648-L654)