### PR TITLE
Use selectPin rather than SS in initSPI

### DIFF
--- a/src/enc28j60.cpp
+++ b/src/enc28j60.cpp
@@ -232,8 +232,8 @@ static byte Enc28j60Bank;
 static byte selectPin;
 
 void ENC28J60::initSPI () {
-    pinMode(SS, OUTPUT);
-    digitalWrite(SS, HIGH);
+    pinMode(selectPin, OUTPUT);
+    digitalWrite(selectPin, HIGH);
     pinMode(MOSI, OUTPUT);
     pinMode(SCK, OUTPUT);
     pinMode(MISO, INPUT);
@@ -365,9 +365,12 @@ static void writePhy (byte address, uint16_t data) {
 
 byte ENC28J60::initialize (uint16_t size, const byte* macaddr, byte csPin) {
     bufferSize = size;
+
+    selectPin = csPin;
+
     if (bitRead(SPCR, SPE) == 0)
         initSPI();
-    selectPin = csPin;
+
     pinMode(selectPin, OUTPUT);
     disableChip();
 
@@ -653,9 +656,12 @@ uint8_t ENC28J60::doBIST ( byte csPin) {
 #define RANDOM_RACE     0b1100
 
 // init
+
+    selectPin = csPin;
+
     if (bitRead(SPCR, SPE) == 0)
         initSPI();
-    selectPin = csPin;
+
     pinMode(selectPin, OUTPUT);
     disableChip();
 


### PR DESCRIPTION
I had an issue where I wanted to use digital pin 10 on the Arduino Nano for a purpose other than chip select, but the pin state was changing at boot when I did not expect it to.

I traced this to the `initSPI` method, which uses the hardcoded `SS` define rather than the `selectPin` variable.

This change fixes this in `initSPI`, as well as ensuring that `selectPin` is correctly set before `initSPI` is called.